### PR TITLE
Secure api integration with proxy and demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Jeu-Amour-Pays-Origines-
+# Amour à travers le monde — Proxy Gemini
+
+- Déployez un proxy Cloudflare Workers pour appeler Gemini sans exposer la clé côté client.
+- En local, vous pouvez tester en « mode démo »: l’app demandera une clé API temporaire (non sauvegardée).
+
+## Cloudflare Workers
+1. `npm create cloudflare@latest` (ou utilisez les fichiers ci-dessous si présents: `wrangler.toml`, `worker/src/index.ts`).
+2. Ajoutez la variable `GEMINI_API_KEY` via `wrangler secret put GEMINI_API_KEY`.
+3. Déployez: `npx wrangler deploy`.
+4. Configurez un route (`/api/gemini/generate-romance`) ou utilisez un sous-domaine du worker et mettez-le dans `PROXY_GEMINI_URL` si besoin.
+
+## Mode démo
+- Cliquez « Générer un message mignon 💌 ». Si le proxy n’est pas dispo, une invite vous demandera une clé API Gemini. Rien n’est stocké.

--- a/cf-worker/src/index.ts
+++ b/cf-worker/src/index.ts
@@ -1,0 +1,97 @@
+export interface Env {
+  GEMINI_API_KEY: string;
+}
+
+interface InBody {
+  h: { code: string; name: string; flag: string };
+  f: { code: string; name: string; flag: string };
+  distanceKm: number;
+  score: number;
+  nameA: string;
+  nameB: string;
+  lang?: string;
+}
+
+function composeFallback(b: InBody) {
+  const formatKm = (km: number) => new Intl.NumberFormat('fr-FR').format(Math.round(km)) + ' km';
+  const hearts = ['💞','💖','💗','💘','💝'];
+  const pick = (arr: string[]) => arr[Math.floor(Math.random() * arr.length)];
+  const extra = '';
+  const fr = `${b.nameA}${extra} (${b.h.flag} ${b.h.name}) et ${b.nameB}${extra} (${b.f.flag} ${b.f.name}) sont séparés par ${formatKm(b.distanceKm)}, mais leurs cœurs n’ont pas de frontières. Compatibilité: ${b.score}/100 ${pick(hearts)}`;
+  const dj_lat = `${b.nameA}${extra} w ${b.nameB}${extra} b3id bainathom ${formatKm(b.distanceKm)}, walakin l9loub ma 3and-homch hdoud. N9ta: ${b.score}/100 ${pick(hearts)}`;
+  const dj_ar = `${b.nameA}${extra} و ${b.nameB}${extra} بعيد بيناتهم ${formatKm(b.distanceKm)}، ولكن القلوب ما عندهاش حدود. النقطة: ${b.score}/100 ${pick(hearts)}`;
+  return { fr, darija_lat: dj_lat, darija_ar: dj_ar };
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    // CORS preflight
+    if (request.method === 'OPTIONS') {
+      return new Response(null, {
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods': 'POST,OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+          'Access-Control-Max-Age': '86400',
+        },
+      });
+    }
+
+    if (request.method !== 'POST' || !url.pathname.endsWith('/api/gemini/generate-romance')) {
+      return new Response('Not found', { status: 404 });
+    }
+
+    let body: InBody | null = null;
+    try {
+      body = await request.json();
+    } catch {
+      return new Response(JSON.stringify({ error: 'invalid_json' }), { status: 400, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' } });
+    }
+    if (!body) {
+      return new Response(JSON.stringify({ error: 'missing_body' }), { status: 400, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' } });
+    }
+
+    const key = env.GEMINI_API_KEY;
+    if (!key) {
+      const messages = composeFallback(body);
+      return new Response(JSON.stringify({ messages, mode: 'fallback' }), { status: 200, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' } });
+    }
+
+    const sys = 'Tu es un assistant qui écrit des messages romantiques courts, mignons et variés. Garde un ton chaleureux, pas trop long.';
+    const promptFr = `Crée un court message romantique en français pour ${body.nameA} (${body.h.flag} ${body.h.name}) et ${body.nameB} (${body.f.flag} ${body.f.name}). Distance: ${Math.round(body.distanceKm)} km. Score: ${body.score}/100.`;
+    const promptDjLat = `En darija (latin), une variante courte et mignonne pour ${body.nameA} (${body.h.flag}) et ${body.nameB} (${body.f.flag}).`;
+    const promptDjAr = `بالدارجة المغربية (العربية)، رسالة قصيرة وجميلة لـ ${body.nameA} (${body.h.flag}) و ${body.nameB} (${body.f.flag}).`;
+    const contents = [
+      { role: 'user', parts: [{ text: sys + '\n' + promptFr }] },
+      { role: 'user', parts: [{ text: promptDjLat }] },
+      { role: 'user', parts: [{ text: promptDjAr }] },
+    ];
+
+    try {
+      const apiRes = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'x-goog-api-key': key },
+          body: JSON.stringify({ contents })
+        }
+      );
+      if (!apiRes.ok) throw new Error('gemini_error');
+      const data = await apiRes.json();
+      const text = data?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+      const lines = String(text).split(/\n+/).filter(Boolean);
+      const fallback = composeFallback(body);
+      const messages = {
+        fr: lines[0] || fallback.fr,
+        darija_lat: lines[1] || fallback.darija_lat,
+        darija_ar: lines[2] || fallback.darija_ar,
+      };
+      return new Response(JSON.stringify({ messages, mode: 'gemini' }), { status: 200, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' } });
+    } catch (e) {
+      const messages = composeFallback(body);
+      return new Response(JSON.stringify({ messages, mode: 'fallback_error' }), { status: 200, headers: { 'Content-Type': 'application/json', 'Access-Control-Allow-Origin': '*' } });
+    }
+  },
+};

--- a/index.html
+++ b/index.html
@@ -326,7 +326,11 @@
      const btnCopy = $('#btnCopy');
      const scoreLine = $('#scoreLine');
      const out = $('#out');
-     const btnDownload = $('#btnDownload');
+           const btnDownload = $('#btnDownload');
+
+      // Gemini proxy endpoint and demo key (not persisted)
+      const PROXY_GEMINI_URL = '/api/gemini/generate-romance';
+      let DEMO_GEMINI_API_KEY = null;
 
     const canvas = document.getElementById('map');
     const ctx = canvas.getContext('2d');
@@ -883,7 +887,64 @@
 
     function pick(arr) { return arr[Math.floor(Math.random() * arr.length)]; }
 
-    function generateMessage() {
+    async function generateViaProxy({ h, f, distanceKm, score, nameA, nameB }) {
+      const body = {
+        h: { code: h.code, name: h.name, flag: h.flag },
+        f: { code: f.code, name: f.name, flag: f.flag },
+        distanceKm,
+        score,
+        nameA,
+        nameB,
+        lang: (langSelect && langSelect.value) || 'fr'
+      };
+      const res = await fetch(PROXY_GEMINI_URL, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body)
+      });
+      if (!res.ok) throw new Error('proxy_failed');
+      const data = await res.json();
+      if (!data || !data.messages) throw new Error('bad_proxy_payload');
+      return data.messages;
+    }
+
+    async function generateViaGeminiDirect({ h, f, distanceKm, score, nameA, nameB }) {
+      if (!DEMO_GEMINI_API_KEY) {
+        const maybe = prompt('Mode démo: colle une clé API Gemini temporaire. Elle ne sera PAS sauvegardée.');
+        if (!maybe) throw new Error('no_demo_key');
+        DEMO_GEMINI_API_KEY = maybe.trim();
+      }
+      const sys = 'Tu es un assistant qui écrit des messages romantiques courts, mignons et variés. Garde un ton chaleureux, pas trop long.';
+      const promptFr = `Crée un court message romantique en français pour ${nameA} (${h.flag} ${h.name}) et ${nameB} (${f.flag} ${f.name}). Distance: ${Math.round(distanceKm)} km. Score: ${score}/100.`;
+      const promptDjLat = `En darija (latin), une variante courte et mignonne pour ${nameA} (${h.flag}) et ${nameB} (${f.flag}).`;
+      const promptDjAr = `بالدارجة المغربية (العربية)، رسالة قصيرة وجميلة لـ ${nameA} (${h.flag}) و ${nameB} (${f.flag}).`;
+
+      const contents = [
+        { role: 'user', parts: [{ text: sys + '\n' + promptFr }] },
+        { role: 'user', parts: [{ text: promptDjLat }] },
+        { role: 'user', parts: [{ text: promptDjAr }] }
+      ];
+
+      const res = await fetch('https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=' + encodeURIComponent(DEMO_GEMINI_API_KEY), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ contents })
+      });
+      if (!res.ok) throw new Error('gemini_direct_failed');
+      const data = await res.json();
+      const text = (data.candidates && data.candidates[0] && data.candidates[0].content && data.candidates[0].content.parts && data.candidates[0].content.parts[0] && data.candidates[0].content.parts[0].text) || '';
+
+      // Try to split 3 lines; otherwise reuse local composer for structure
+      const lines = text.split(/\n+/).filter(Boolean);
+      const fallback = composeMessages({ h, f, distanceKm, score, nameA, nameB });
+      return {
+        fr: lines[0] || fallback.fr,
+        darija_lat: lines[1] || fallback.darija_lat,
+        darija_ar: lines[2] || fallback.darija_ar
+      };
+    }
+
+    async function generateMessage() {
       const h = getCountry(selectH.value);
       const f = getCountry(selectF.value);
       const { distanceKm, score } = computeCompatibility(h, f, `${nameH.value}|${nameF.value}`);
@@ -891,7 +952,23 @@
       const nameA = nameH.value || 'Adam';
       const nameB = nameF.value || 'Eva';
 
-      const messages = composeMessages({ h, f, distanceKm, score, nameA, nameB });
+      // Try server proxy (no API key on client)
+      let messages = null;
+      try {
+        messages = await generateViaProxy({ h, f, distanceKm, score, nameA, nameB });
+      } catch (_) {}
+
+      // If proxy unavailable, try demo mode (prompt for temporary key, not saved)
+      if (!messages) {
+        try {
+          messages = await generateViaGeminiDirect({ h, f, distanceKm, score, nameA, nameB });
+        } catch (_) {}
+      }
+
+      // Fallback to local templates if all else fails
+      if (!messages) {
+        messages = composeMessages({ h, f, distanceKm, score, nameA, nameB });
+      }
 
       const choice = (langSelect && langSelect.value) ? langSelect.value : 'fr';
       let html = '';

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,11 @@
+name = "amour-gemini-proxy"
+main = "cf-worker/src/index.ts"
+compatibility_date = "2024-09-01"
+
+# Example of routes (replace with your domain/zone)
+# routes = [
+#   { pattern = "example.com/api/gemini/*", zone_name = "example.com" }
+# ]
+
+[vars]
+# No plaintext key here. Use `wrangler secret put GEMINI_API_KEY`.


### PR DESCRIPTION
Add Cloudflare Worker proxy and client-side demo mode for Gemini API to secure API key and facilitate local testing.

---
<a href="https://cursor.com/background-agent?bcId=bc-a978c019-af44-4824-a057-53f5a8225bea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a978c019-af44-4824-a057-53f5a8225bea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

